### PR TITLE
Fix Mixed Content Error for File Downloads

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = request.nextUrl.searchParams.get('url');
+    
+    if (!url) {
+      return NextResponse.json(
+        { error: 'URL parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/pdf',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
+      }
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch file from source' },
+        { status: response.status }
+      );
+    }
+
+    const contentType = response.headers.get('content-type');
+    const contentDisposition = response.headers.get('content-disposition');
+    
+    const blob = await response.blob();
+    
+    return new NextResponse(blob, {
+      headers: {
+        'Content-Type': contentType || 'application/pdf',
+        'Content-Disposition': contentDisposition || 'attachment',
+        'Cache-Control': 'public, max-age=3600'
+      }
+    });
+
+  } catch (error) {
+    console.error('Proxy error:', error);
+    return NextResponse.json(
+      { 
+        error: 'Failed to proxy request',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    );
+  }
+} 

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -2,11 +2,9 @@ import { toast } from 'sonner';
 
 export async function downloadFile(url: string, fileName: string): Promise<boolean> {
   try {
-    const response = await fetch(url, {
-      headers: {
-        'Accept': 'application/pdf'
-      }
-    });
+
+    const proxyUrl = `/api/proxy?url=${encodeURIComponent(url)}`;
+    const response = await fetch(proxyUrl);
     
     if (!response.ok) {
       throw new Error('Download failed');


### PR DESCRIPTION
## Description
- Implements a proxy solution to resolve Mixed Content errors when downloading files.

## Changes Made
- Added `/api/proxy` route for secure downloads
- Updated download utility to use proxy
- Added error handling and caching

## Testing Steps
1. Deploy to HTTPS environment
2. Test file downloads
3. Check browser console for warnings

Fixes #3 