### PR TITLE
feat: hide browse interface for development use only

### DIFF
--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -6,7 +6,13 @@ import { toast } from 'sonner';
 import Layout from '@/components/layout/Layout';
 import DirectoryBrowser from '@/components/directory/DirectoryBrowser';
 import { usePapers } from '@/contexts/PaperContext';
-import type { DirectoryNode } from '@/types/paper';
+import type { DirectoryNode, Paper } from '@/types/paper';
+
+// Extending Paper type for development purposes
+// This will be properly added to Paper interface in Phase 1
+interface PaperWithSubject extends Paper {
+  subject?: string;
+}
 
 function getCurrentNode(structure: DirectoryNode, path: string): DirectoryNode | null {
   if (!path) return structure;
@@ -84,7 +90,14 @@ function BrowseContent() {
     name,
     isDirectory: node.type === 'directory',
     path: node.path,
-    metadata: node.metadata
+    metadata: node.metadata && {
+      ...node.metadata,
+      year: node.metadata.year || 'Unknown',
+      branch: node.metadata.branch || 'Unknown',
+      semester: node.metadata.semester || 'Unknown',
+      examType: node.metadata.examType || 'Unknown',
+      subject: (node.metadata as PaperWithSubject).subject || 'Unknown'
+    }
   }));
 
   return (
@@ -110,6 +123,9 @@ function LoadingFallback() {
 export default function BrowsePage() {
   return (
     <Layout>
+      <div className="mb-4 rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-4 text-yellow-500">
+        <strong>Developer Notice:</strong> This page is now hidden from regular navigation but maintained for development and verification purposes.
+      </div>
       <Suspense fallback={<LoadingFallback />}>
         <BrowseContent />
       </Suspense>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,15 +11,7 @@ export default function HomePage() {
         <p className="mt-2 text-lg text-content/80">
           MITAOE Question Papers
         </p>
-        <div className="mt-16 flex items-center gap-6">
-          <Link
-            href="/browse"
-            className="group rounded-lg border border-accent bg-secondary px-6 py-2.5 text-sm font-medium"
-          >
-            <span className="bg-gradient-to-r from-content to-white bg-clip-text text-transparent transition-all group-hover:text-white">
-              Browse Directory
-            </span>
-          </Link>
+        <div className="mt-16 flex items-center justify-center">
           <Link
             href="/papers"
             className="rounded-lg bg-white px-6 py-2.5 text-sm font-medium text-primary transition-colors hover:bg-content"

--- a/src/components/directory/DirectoryBrowser.tsx
+++ b/src/components/directory/DirectoryBrowser.tsx
@@ -14,6 +14,7 @@ interface DirectoryItem {
     branch: string;
     semester: string;
     examType: string;
+    subject?: string;
   };
 }
 
@@ -149,21 +150,39 @@ export default function DirectoryBrowser({
             {files.map((item) => (
               <div
                 key={item.path}
-                className="flex items-center justify-between p-3 transition-colors hover:bg-accent/10"
+                className="flex flex-col p-3 transition-colors hover:bg-accent/10"
                 onContextMenu={preventRightClick}
               >
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-content">{item.name}</span>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm text-content">{item.name}</span>
+                  </div>
+                  {item.metadata && (
+                    <button
+                      onClick={() => handleDownload(item.metadata!.url, item.metadata!.fileName)}
+                      disabled={downloadingFile === item.metadata.fileName}
+                      className="flex items-center gap-2 rounded-md bg-accent/90 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-accent hover:shadow-accent/25 focus:outline-none focus:ring-2 focus:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <DownloadIcon className={`h-4 w-4 ${downloadingFile === item.metadata.fileName ? 'animate-spin' : ''}`} />
+                      <span>{downloadingFile === item.metadata.fileName ? 'Downloading...' : 'Download'}</span>
+                    </button>
+                  )}
                 </div>
                 {item.metadata && (
-                  <button
-                    onClick={() => handleDownload(item.metadata!.url, item.metadata!.fileName)}
-                    disabled={downloadingFile === item.metadata.fileName}
-                    className="flex items-center gap-2 rounded-md bg-accent/90 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-accent hover:shadow-accent/25 focus:outline-none focus:ring-2 focus:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <DownloadIcon className={`h-4 w-4 ${downloadingFile === item.metadata.fileName ? 'animate-spin' : ''}`} />
-                    <span>{downloadingFile === item.metadata.fileName ? 'Downloading...' : 'Download'}</span>
-                  </button>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {Object.entries(item.metadata).map(([key, value]) => {
+                      if (key === 'url' || key === 'fileName') return null;
+                      if (!value) return null;
+                      return (
+                        <span
+                          key={key}
+                          className="rounded-full bg-primary/50 px-2 py-0.5 text-xs text-content/80"
+                        >
+                          {key}: {value}
+                        </span>
+                      );
+                    })}
+                  </div>
                 )}
               </div>
             ))}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
 export default function Header() {
-  const pathname = usePathname();
-
   return (
     <header className="sticky top-0 z-50 border-b border-accent bg-primary">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
@@ -15,29 +12,6 @@ export default function Header() {
         >
           <span className="ml-1 text-content">MITAOE PYQs</span>
         </Link>
-
-        <nav className="absolute left-1/2 flex -translate-x-1/2 items-center gap-8">
-          <Link
-            href="/browse"
-            className={`text-sm font-medium transition-colors ${
-              pathname === '/browse' 
-                ? 'text-white' 
-                : 'text-content/60 hover:text-white'
-            }`}
-          >
-            Browse
-          </Link>
-          <Link
-            href="/papers"
-            className={`text-sm font-medium transition-colors ${
-              pathname === '/papers' 
-                ? 'text-white' 
-                : 'text-content/60 hover:text-white'
-            }`}
-          >
-            Search
-          </Link>
-        </nav>
 
         <a
           href="https://github.com/AdityaKotkar47/mitaoe-pyqs"


### PR DESCRIPTION
## Changes
This PR implements Phase 2 of the UI revamp, hiding the browse navigation while maintaining its functionality for development purposes.

### Completed Tasks
- ✅ Removed `/browse` link from header navigation
- ✅ Removed "Browse Directory" button from homepage
- ✅ Updated header to focus on search functionality
- ✅ Maintained `/browse` route functionality for development
- ✅ Enhanced `/browse` page with:
  - Added developer notice banner
  - Improved file metadata display with tags
  - Added placeholder for subject tags (to be populated in Phase 1)
  - Made metadata discrepancies visually apparent with "Unknown" labels

### Implementation Details
1. **Header Navigation**
   - Simplified navigation by removing browse link
   - Removed unused pathname tracking
   - Maintained GitHub link

2. **Homepage**
   - Removed directory browsing option
   - Centered and emphasized search functionality
   - Cleaner, more focused UI

3. **Browse Page**
   - Added yellow warning banner for developer notice
   - Enhanced file items to show all metadata as tags
   - Added subject tag placeholder (shows "Unknown" until Phase 1)
   - Improved metadata visibility for development verification

## Screenshots
   - before
   
   
![image](https://github.com/user-attachments/assets/26426b87-dbce-402f-bfe4-7f45fe0e478e)

![image](https://github.com/user-attachments/assets/dea29bbe-bec8-429b-9588-7c78b4f45bac)


   - after
  
![image](https://github.com/user-attachments/assets/e60fce14-7424-4ac5-94f4-ae49ad17e481)

   
![image](https://github.com/user-attachments/assets/ee090921-202c-443c-ab4c-db7ec8b9013e)


Closes #5